### PR TITLE
Stories/378 configurable words aloud

### DIFF
--- a/memoryexpt2/config.txt
+++ b/memoryexpt2/config.txt
@@ -7,6 +7,7 @@ assign_qualifications = true
 mexp_topology = collaborative
 mexp_turn_type = random_turns
 mexp_transmission_mode = promiscuous
+mexp_words_aloud = true
 
 [MTurk]
 title = Memory test

--- a/memoryexpt2/experiment.py
+++ b/memoryexpt2/experiment.py
@@ -33,6 +33,14 @@ def serve_game():
     return flask.render_template("experiment.html")
 
 
+@extra_routes.route("/instructions")
+def serve_instructions():
+    """Render the instructions as a Flask template, so we can include
+    interpolated values from the Experiment.
+    """
+    return flask.render_template("instructions.html")
+
+
 def extra_parameters():
     config = dlgr.config.get_config()
     config.register('mexp_topology', six.text_type, [], False)

--- a/memoryexpt2/experiment.py
+++ b/memoryexpt2/experiment.py
@@ -38,6 +38,7 @@ def extra_parameters():
     config.register('mexp_topology', six.text_type, [], False)
     config.register('mexp_turn_type', six.text_type, [], False)
     config.register('mexp_transmission_mode', six.text_type, [], False)
+    config.register('mexp_words_aloud', bool, [], False)
 
 
 class CoordinationChatroom(dlgr.experiments.Experiment):
@@ -53,6 +54,7 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
         self.num_participants = 2 #55 #55 #140 below
         self.initial_recruitment_size = self.num_participants * 1 #note: can't do *2.5 here, won't run even if the end result is an integer
         self.quorum = self.num_participants  # quorum is read by waiting room
+        self.words_aloud = config.get(u'mexp_words_aloud', False)
         self.topology = topologies.by_name(
             config.get(u'mexp_topology', u'collaborative')
         )

--- a/memoryexpt2/static/scripts/pubsub.js
+++ b/memoryexpt2/static/scripts/pubsub.js
@@ -86,19 +86,19 @@ var pubsub = (function ($, ReconnectingWebSocket) {
         /*
          * Public API
          */
-        var Socket = function (settings) {
+        var Socket = function (options) {
             if (!(this instanceof Socket)) {
-                return new Socket(settings);
+                return new Socket(options);
             }
 
             var self = this,
-                tolerance = typeof(settings.lagTolerance) !== "undefined" ? settings.lagTolerance : 0.1;
+                tolerance = typeof(options.lagTolerance) !== "undefined" ? options.lagTolerance : 0.1;
 
-            this.broadcastChannel = settings.broadcast;
-            this.controlChannel = settings.control;
+            this.broadcastChannel = options.broadcast;
+            this.controlChannel = options.control;
             this._pubsub = PubSub();
             this._socket = makeSocket(
-                settings.endpoint, this.broadcastChannel, tolerance);
+                options.endpoint, this.broadcastChannel, tolerance);
 
             this._socket.onmessage = function (event) {
                 var msg = parse(self, event);

--- a/memoryexpt2/templates/experiment.html
+++ b/memoryexpt2/templates/experiment.html
@@ -5,6 +5,7 @@
     // Parameters
     settings = {};
     settings.enforceTurns = {% if experiment.enforce_turns %}true{% else %}false{% endif %};
+    settings.wordsAloud = {% if experiment.words_aloud %}true{% else %}false{% endif %};
 </script>
 {% endblock %}
 
@@ -55,10 +56,14 @@
 
     <div id="response-form" style="display:none;">
         <p> Good! Now recall the words you saw
-          by typing them below. If there are other people in this chatroom,
-          they will also be able to contribute words, which will be read aloud to you.
-         If you are in a game where you're taking turns with people in the chatroom, know that you can either type a word that hasn't been typed yet, or pass, to complete your turn.</p>
-          <p>Please recall as many words as possible! You will receive a bonus based on how many words you (and whoever is in this chatroom) <i>correctly</i> recall.</p>
+          by typing them below. If there are other people in this chatroom, they will also
+          be able to contribute words{% if experiment.words_aloud %}, which will be read aloud to you{% endif %}.
+          If you are in a game where you're taking turns with people in the chatroom,
+         know that you can either type a word that hasn't been typed yet, or pass, to complete your turn.
+        </p>
+        <p>Please recall as many words as possible! You will receive a bonus based on how many words
+            you (and whoever is in this chatroom) <i>correctly</i> recall.
+        </p>
         <h4> Submit one word at a time, no spaces. You will not be able to submit words already listed (by you or others).</h4>
         <br>
         <!-- Shows the seconds left in the current turn, and who's turn it is. -->

--- a/memoryexpt2/templates/instructions.html
+++ b/memoryexpt2/templates/instructions.html
@@ -1,48 +1,54 @@
 {% extends "layout.html" %}
 
-{% block libs %}
-    {{ super() }}
-    <script src="/static/scripts/instructions.js" type="text/javascript"> </script>
-{% endblock %}
-
 {% block body %}
     <div class="main_div">
         <h1>Instructions</h1>
         <hr>
-        <h3>Test your speakers</h3>
-        <p>
-            Please type the sentence you hear after pressing the button below.
-        </p>
-        <button type="button" id="test-sound" class="btn btn-lg btn-primary">Hear Phrase</button>
-        <br>
-        <input type="text" id="heard-as" size="60" />
-        <button type="button" id="compare-phrases" class="btn btn-lg btn-primary">Compare</button>
-        <br>
-        <div id="sound-test-result">
-        </div>
-        <br>
+        {% if experiment.words_aloud %}
+            <h3>Test your speakers</h3>
+            <p>
+                Please type the sentence you hear after pressing the button below.
+            </p>
+            <button type="button" id="test-sound" class="btn btn-lg btn-primary">Hear Phrase</button>
+            <br>
+            <input type="text" id="heard-as" size="60" />
+            <button type="button" id="compare-phrases" class="btn btn-lg btn-primary">Compare</button>
+            <br>
+            <div id="sound-test-result">
+            </div>
+            <br>
+        {% endif %}
+
         <h4>In this experiment, you will see a list of words presented one at
-              a time. Try to remember as many as possible: you will be tested on these words later. </h4>
-              <br>
-              <p> You will now either be directed to a waiting room,
-            or the words could begin appearing immediately!</p>
-              <br>
-              <!--<p> *If you have already successfully completed a "Memory test" experiment
-                (meaning you have seen the words and done the task), we request that
-                you please do not accept this HIT. </p>
-                -->
-              <p>
-              <br>
-            <p><i>(Note that if you get stuck in the waiting room for more than 10 minutes, please return the HIT and email </i>mgates@berkeley.edu<i> for full compensation.)</i></p>
-          <br>
+            a time. Try to remember as many as possible: you will be tested on these words later.
+        </h4>
+        <br>
+        <p> You will now either be directed to a waiting room,
+            or the words could begin appearing immediately!
+        </p>
+        <br>
+        <!--<p> *If you have already successfully completed a "Memory test" experiment
+        (meaning you have seen the words and done the task), we request that
+        you please do not accept this HIT. </p>
+        -->
+        <p><i>(Note that if you get stuck in the waiting room for more than 10 minutes, please return the HIT and email </i>mgates@berkeley.edu<i> for full compensation.)</i></p>
+        <br>
         <hr>
         <div>
             <div class="row">
                 <div class="col-xs-10"></div>
                 <div class="col-xs-2">
-                    <button type="button" disabled id="go-to-waiting-room" class="btn btn-success btn-lg">Begin</button>
+                    <button type="button" id="go-to-waiting-room" class="btn btn-success btn-lg"
+                            {% if experiment.words_aloud %} disabled {% endif %}>
+                        Begin
+                    </button>
                 </div>
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block libs %}
+    {{ super() }}
+    <script src="/static/scripts/instructions.js" type="text/javascript"> </script>
 {% endblock %}


### PR DESCRIPTION
Updates to experiment and instructions to vary behavior based on boolean `mexp_words_aloud` config variable.

A big chunk of the diff is a rename of a JS variable `settings` to `options`, primarily for values passed to object constructor functions. This wasn't strictly necessary, but it disambiguates these variables from the global `settings` var that includes contains values passed in from the python experiment class. I think `options` is a more standard name for this argument object literal anyway.